### PR TITLE
Fixed numpy version to <2 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ with open("README.md", "r") as readme_file:
         install_requires=[
             "pathos", "appdirs", "deprecation", "jinja2>=3.1.2", "matplotlib",
             "numpngw",
-            "numpy", "pandas>=1.4.1", "imageio",
+            "numpy<=1.26.3", "pandas>=1.4.1", "imageio",
             "pdf2image", "psutil", "requests", "scipy", "sortedcontainers",
             "astropy", "natsort", "rich", "h5py"],
 


### PR DESCRIPTION
Fixed numpy version to <=1.26.3 due to [backwards compatibility issues](https://numpy.org/devdocs/release/2.0.0-notes.html#:~:text=Backwards%20compatibility) in version 2


Example in lc plugin when running
```
enb plugin install lossless-compression ./lc
cd lc
enb plugin install lcnl plugins/lcnl
python3 ./lossless_compression_experiment.py
```

Getting the following error:

```
╭─ ScalarNumericSummary ───────────────────────────────────────────────────────────────────────────────────────────────╮
│   Rows  : 2/2                       0.2s                                                                             │
│   Chunks: 1/1              100.0%   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
Error rendering to plots/ScalarNumericAnalyzer-compression_time_seconds-histogram-groupby__task_label.pdf:
ValueError('Unable to avoid copy while creating an array as requested.\nIf using `np.array(obj, copy=False)` replace it
with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).\nFor more details, see
https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.')
Error rendering to plots/ScalarNumericAnalyzer-decompression_time_seconds-histogram-groupby__task_label.pdf:
ValueError('Unable to avoid copy while creating an array as requested.\nIf using `np.array(obj, copy=False)` replace it
with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).\nFor more details, see
https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.')
Error rendering to plots/ScalarNumericAnalyzer-compression_ratio_dr-histogram-groupby__task_label.pdf:
ValueError('Unable to avoid copy while creating an array as requested.\nIf using `np.array(obj, copy=False)` replace it
with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).\nFor more details, see
https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.')
Error rendering to plots/ScalarNumericAnalyzer-compression_efficiency_2byte_entropy-histogram-groupby__task_label.pdf:
ValueError('Unable to avoid copy while creating an array as requested.\nIf using `np.array(obj, copy=False)` replace it
with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).\nFor more details, see
https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.')
Error rendering to plots/ScalarNumericAnalyzer-compression_efficiency_1byte_entropy-histogram-groupby__task_label.pdf:
ValueError('Unable to avoid copy while creating an array as requested.\nIf using `np.array(obj, copy=False)` replace it
with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).\nFor more details, see
https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.')
Error rendering to plots/ScalarNumericAnalyzer-bpppc-histogram-groupby__task_label.pdf:
ValueError('Unable to avoid copy while creating an array as requested.\nIf using `np.array(obj, copy=False)` replace it
with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).\nFor more details, see
https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.')
╭─ ScalarNumericAnalyzer ──────────────────────────────────────────────────────────────────────────────────────────────╮
│ ⠴ Rows  : 0/6                       0.4s                                                                             │
│   Chunks: 0/1                0.0%   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
multiprocess.pool.RemoteTraceback:
"""
Traceback (most recent call last):
  File "/home/ohad/.local/lib/python3.10/site-packages/multiprocess/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/home/ohad/.local/lib/python3.10/site-packages/enb/render.py", line 113, in parallel_render_plds_by_group
    raise ex
  File "/home/ohad/.local/lib/python3.10/site-packages/enb/render.py", line 73, in parallel_render_plds_by_group
    return render_plds_by_group(pds_by_group_name=pds_by_group_name,
  File "/home/ohad/.local/lib/python3.10/site-packages/enb/render.py", line 309, in render_plds_by_group
    _update_axes(
  File "/home/ohad/.local/lib/python3.10/site-packages/enb/render.py", line 671, in _update_axes
    global_x_max, global_x_min, global_y_max, global_y_min = _get_global_extrema(
  File "/home/ohad/.local/lib/python3.10/site-packages/enb/render.py", line 572, in _get_global_extrema
    x_values = np.array(pld.x_values, copy=False)
ValueError: Unable to avoid copy while creating an array as requested.
If using `np.array(obj, copy=False)` replace it with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).
For more details, see https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ohad/lc/./lossless_compression_experiment.py", line 93, in <module>
    scalar_analyzer.get_df(
  File "/home/ohad/.local/lib/python3.10/site-packages/enb/aanalysis.py", line 282, in get_df
    return normalized_wrapper(self=self, full_df=full_df,
  File "/home/ohad/.local/lib/python3.10/site-packages/enb/aanalysis.py", line 657, in wrapper
    return fun(self=self, full_df=full_df,
  File "/home/ohad/.local/lib/python3.10/site-packages/enb/aanalysis.py", line 250, in normalized_wrapper
    self.render_all_modes(
  File "/home/ohad/.local/lib/python3.10/site-packages/enb/aanalysis.py", line 366, in render_all_modes
    enb.parallel.get(render_ids)
  File "/home/ohad/.local/lib/python3.10/site-packages/enb/parallel.py", line 66, in get
    return fallback_get(ids, **kwargs)
  File "/home/ohad/.local/lib/python3.10/site-packages/enb/parallel.py", line 129, in fallback_get
    return [fallback_future.get(**kwargs) for fallback_future in ids]
  File "/home/ohad/.local/lib/python3.10/site-packages/enb/parallel.py", line 129, in <listcomp>
    return [fallback_future.get(**kwargs) for fallback_future in ids]
  File "/home/ohad/.local/lib/python3.10/site-packages/enb/parallel.py", line 100, in get
    return self.pathos_result.get(**kwargs)
  File "/home/ohad/.local/lib/python3.10/site-packages/multiprocess/pool.py", line 774, in get
    raise self._value
ValueError: Unable to avoid copy while creating an array as requested.
If using `np.array(obj, copy=False)` replace it with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).
For more details, see https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.
```

Fixing numpy package to version 1.26.3 has solved the issue